### PR TITLE
#163, #164, #165, #166: Bug fix and UX improvement for plugin step registration and attribute selection

### DIFF
--- a/Xrm.Sdk.PluginRegistration.nuspec
+++ b/Xrm.Sdk.PluginRegistration.nuspec
@@ -23,8 +23,9 @@ New features
 - #78: Added a refresh option for available messages (including newly added Custom Actions) without restarting the tool
 - #84: Export now includes Webhook (Service Endpoint) information
 - #150: Show dependencies for a plugin assembly (button + context menu entry)
+- #166: Allow pasting a comma-separated list of attribute logical names into the Filtering Attributes dialog to directly select attributes (paste-to-select UX improvement)
 
-UX &amp; stability improvements
+UX &amp; stability improvements, bug fixes
 - #66: Prevent invalid image registration by disabling Pre-Image for Create steps (Create does not support this image type)
 - #129: Prevent accidental "Save &amp; Close" when pressing Enter in the Step editor
 - #146: Step Configuration editor improvements: monospaced font for JSON/XML, resizable dialog with splitter, word wrap off, and safer default-button behavior to avoid accidental updates
@@ -33,6 +34,9 @@ UX &amp; stability improvements
 - #155: Toolbar button fixes
 - #158: GCC High error when loading Plugin Packages
 - #160: Null Reference Exception on Update button
+- #163: Cannot register step with Primary Entity = none
+- #165: Restrict "All Attributes" warning to non-Create messages
+- #164: Filtering Attributes not available for Create steps on Dynamics 365 9.1 on-prem
 		</releaseNotes>
 
 		<tags>XrmToolBox Plugins PluginRegistration</tags>

--- a/Xrm.Sdk.PluginRegistration/Forms/AttributeSelectionForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/AttributeSelectionForm.cs
@@ -219,9 +219,78 @@ namespace Xrm.Sdk.PluginRegistration.Forms
 
         private void txtFilter_TextChanged(object sender, EventArgs e)
         {
+            // If the user pasted a comma-separated list of logical names, treat it as a direct selection
+            // rather than normal incremental filtering. This avoids disturbing normal filtering behavior
+            // for other uses of the filter box.
+            try
+            {
+                if (TrySelectAttributesFromPaste(txtFilter.Text))
+                {
+                    // Clear the filter text after handling the paste so normal filtering is not performed
+                    // and the user sees the selection result immediately.
+                    txtFilter.Text = string.Empty;
+                    return;
+                }
+            }
+            catch
+            {
+                // Fall back to normal filtering on any unexpected error
+            }
+
             searchThread?.Abort();
             searchThread = new Thread(DisplayAttributes);
             searchThread.Start();
+        }
+
+        private bool TrySelectAttributesFromPaste(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text) || !text.Contains(","))
+            {
+                return false;
+            }
+
+            // Split the pasted text into tokens and normalize to lower-case logical names
+            var tokens = text.Split(',')
+                             .Select(t => t.Trim())
+                             .Where(t => !string.IsNullOrEmpty(t))
+                             .Select(t => t.ToLowerInvariant())
+                             .ToArray();
+
+            if (tokens.Length == 0)
+            {
+                return false;
+            }
+
+            // Find matching items from the complete attribute list (not just the filtered view)
+            var matched = m_attributesList.Where(i => tokens.Contains(i.Name)).ToList();
+
+            if (matched.Count == 0)
+            {
+                // No matches found: do not interfere with normal filtering
+                return false;
+            }
+
+            // Replace current selection with the pasted selection: uncheck all then check matched
+            lsvAttributes.ItemChecked -= lsvAttributes_ItemChecked;
+            try
+            {
+                var matchedNames = new HashSet<string>(matched.Select(i => i.Name));
+                foreach (var item in m_attributesList)
+                {
+                    item.Checked = matchedNames.Contains(item.Name);
+                }
+            }
+            finally
+            {
+                lsvAttributes.ItemChecked += lsvAttributes_ItemChecked;
+            }
+
+            RefreshCurrentAndCounts();
+
+            // Ensure the UI displays the attributes (in case none were visible before)
+            DisplayAttributes();
+
+            return true;
         }
 
         #endregion Private Methods

--- a/Xrm.Sdk.PluginRegistration/Forms/AttributeSelectionForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/AttributeSelectionForm.cs
@@ -17,7 +17,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace Xrm.Sdk.PluginRegistration.Forms
 {
@@ -38,7 +37,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
         private CrmOrganization m_org;
         private UpdateImageAttributesDelegate m_updateAttributes;
 
-        private Thread searchThread;
+        private Timer m_filterTimer;
 
         #endregion Private Fields
 
@@ -64,6 +63,15 @@ namespace Xrm.Sdk.PluginRegistration.Forms
 
             m_org = org;
             m_updateAttributes = updateAttributes;
+
+            // debounce timer for filter updates to replace Thread.Abort usage
+            m_filterTimer = new Timer { Interval = 300 };
+            m_filterTimer.Tick += (s, ea) =>
+            {
+                m_filterTimer.Stop();
+                DisplayAttributes();
+            };
+            this.FormClosed += AttributeSelectionForm_FormClosed;
 
             //Create a sorter for the listview. This will allow the list to be sorted by different columns
             lsvAttributes.ListViewItemSorter = new ListViewColumnSorter(0, lsvAttributes.Sorting);
@@ -162,10 +170,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             {
                 lsvAttributes.Items.Clear();
 
+                var filter = txtFilter.Text ?? string.Empty;
                 var items = m_attributesList.Where(i =>
-                    txtFilter.Text.Length == 0
-                    || i.Text.ToLower().IndexOf(txtFilter.Text.ToLower(), StringComparison.Ordinal) >= 0
-                    || i.Name.ToLower().IndexOf(txtFilter.Text.ToLower(), StringComparison.Ordinal) >= 0);
+                    filter.Length == 0
+                    || i.Text.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0
+                    || i.Name.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0);
 
                 lsvAttributes.ItemChecked -= lsvAttributes_ItemChecked;
                 lsvAttributes.Items.AddRange(items.ToArray());
@@ -237,9 +246,30 @@ namespace Xrm.Sdk.PluginRegistration.Forms
                 // Fall back to normal filtering on any unexpected error
             }
 
-            searchThread?.Abort();
-            searchThread = new Thread(DisplayAttributes);
-            searchThread.Start();
+            // Restart debounce timer to refresh view on idle
+            try
+            {
+                m_filterTimer.Stop();
+                m_filterTimer.Start();
+            }
+            catch
+            {
+                // ignore timer errors and fallback to immediate display
+                DisplayAttributes();
+            }
+        }
+
+        private void AttributeSelectionForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            try
+            {
+                m_filterTimer?.Stop();
+                m_filterTimer?.Dispose();
+            }
+            catch
+            {
+                // ignore
+            }
         }
 
         private bool TrySelectAttributesFromPaste(string text)

--- a/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.cs
@@ -608,7 +608,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
 
             if (Message.SupportsFilteredAttributes)
             {
-                if (crmFilteringAttributes.AllAttributes)
+                if (crmFilteringAttributes.AllAttributes && Message.Name != "Create")
                 {
                     if (MessageBox.Show("Registering steps filtering on updates of ALL attributes is highly discouraged for performance reasons.\nPlease reconsider this pattern.\n\nYes, I want to specify explicit attributes.\nNo, I don't care about performance now.", "Registration", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
                     {

--- a/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.cs
@@ -606,7 +606,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
                 }
             }
 
-            if (Message.SupportsFilteredAttributes)
+            if (Message.SupportsFilteredAttributes && crmFilteringAttributes.Enabled)
             {
                 if (crmFilteringAttributes.AllAttributes && Message.Name != "Create")
                 {
@@ -623,7 +623,17 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             }
 
             step.MessageId = Message.MessageId;
-            step.MessageEntityId = MessageEntity.MessageEntityId;
+            // Only set MessageEntityId if primary entity is not "none"
+            // When primary entity is "none", leave MessageEntityId as Guid.Empty to avoid
+            // triggering Dataverse dependency calculation errors for stale sdkmessagefilter records
+            if (!string.Equals(MessageEntity?.PrimaryEntity, "none", StringComparison.InvariantCultureIgnoreCase))
+            {
+                step.MessageEntityId = MessageEntity.MessageEntityId;
+            }
+            else
+            {
+                step.MessageEntityId = Guid.Empty;
+            }
             step.AssemblyId = plugin?.AssemblyId ?? Guid.Empty;
             step.FilteringAttributes = crmFilteringAttributes.Attributes;
             step.PluginId = plugin?.PluginId ?? ((CrmServiceEndpoint)cmbWebhook.SelectedItem).EntityId;

--- a/Xrm.Sdk.PluginRegistration/Helpers/OrganizationHelper.cs
+++ b/Xrm.Sdk.PluginRegistration/Helpers/OrganizationHelper.cs
@@ -1431,7 +1431,7 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
                     break;
 
                 case "Create":
-                    if (org.ConnectionDetail.OrganizationMajorVersion > 9 || (org.ConnectionDetail.OrganizationMajorVersion == 9 && org.ConnectionDetail.OrganizationMinorVersion >= 2))
+                    if (org.ConnectionDetail.OrganizationMajorVersion > 9 || (org.ConnectionDetail.OrganizationMajorVersion == 9 && org.ConnectionDetail.OrganizationMinorVersion >= 1))
                     {
                         message.SupportsFilteredAttributes = true;
                     }

--- a/Xrm.Sdk.PluginRegistration/Helpers/OrganizationHelper.cs
+++ b/Xrm.Sdk.PluginRegistration/Helpers/OrganizationHelper.cs
@@ -1179,7 +1179,8 @@ namespace Xrm.Sdk.PluginRegistration.Helpers
             query.Criteria.FilterOperator = LogicalOperator.And;
             query.EntityName = SdkMessageFilter.EntityLogicalName;
 
-            foreach (var filter in org.OrganizationService.RetrieveMultipleAllPages(query).Entities.Select(x => Magic.CastTo<SdkMessageFilter>(x)))
+            var filterResults = org.OrganizationService.RetrieveMultipleAllPages(query).Entities.Select(x => Magic.CastTo<SdkMessageFilter>(x)).ToList();
+            foreach (var filter in filterResults)
             {
                 var entity = new CrmMessageEntity(org, filter);
                 var message = messages[entity.MessageId];

--- a/Xrm.Sdk.PluginRegistration/Wrappers/CrmPluginStep.cs
+++ b/Xrm.Sdk.PluginRegistration/Wrappers/CrmPluginStep.cs
@@ -730,9 +730,6 @@ namespace Xrm.Sdk.PluginRegistration.Wrappers
             sdkStep.SdkMessageId = new EntityReference();
             sdkStep.SdkMessageId.LogicalName = SdkMessage.EntityLogicalName;
 
-            sdkStep.SdkMessageFilterId = new EntityReference();
-            sdkStep.SdkMessageFilterId.LogicalName = SdkMessageFilter.EntityLogicalName;
-
             if (MessageId == Guid.Empty)
             {
                 sdkStep.SdkMessageId = null;
@@ -741,14 +738,15 @@ namespace Xrm.Sdk.PluginRegistration.Wrappers
             {
                 sdkStep.SdkMessageId.Id = MessageId;
             }
-            if (MessageEntityId == Guid.Empty)
+
+            if (MessageEntityId != Guid.Empty)
             {
-                sdkStep.SdkMessageFilterId = null;
+                sdkStep.SdkMessageFilterId = new EntityReference(SdkMessageFilter.EntityLogicalName, MessageEntityId);
             }
-            else
-            {
-                sdkStep.SdkMessageFilterId.Id = MessageEntityId;
-            }
+            // When MessageEntityId == Guid.Empty (Primary Entity = "none"):
+            // completely omit sdkmessagefilterid from the request rather than
+            // sending null, which triggers Dataverse dependency calculation errors
+            // in orgs with stale sdkmessagefilter records for deleted entities.
             sdkStep.ImpersonatingUserId = new EntityReference();
             sdkStep.ImpersonatingUserId.LogicalName = SystemUser.EntityLogicalName;
 
@@ -767,14 +765,17 @@ namespace Xrm.Sdk.PluginRegistration.Wrappers
             sdkStep.SupportedDeployment = new OptionSetValue();
             sdkStep.SupportedDeployment.Value = (int)Deployment;
 
-            if (string.IsNullOrEmpty(FilteringAttributes))
-            {
-                sdkStep.FilteringAttributes = string.Empty;
-            }
-            else
+            if (!string.IsNullOrEmpty(FilteringAttributes))
             {
                 sdkStep.FilteringAttributes = FilteringAttributes;
             }
+            else if (StepId != Guid.Empty)
+            {
+                // Update: explicitly clear filtering attributes so existing values are removed
+                sdkStep.FilteringAttributes = string.Empty;
+            }
+            // Create with no filtering attributes: omit the field entirely to avoid
+            // triggering Dataverse dependency calculation on the entity type code
 
             sdkStep.AsyncAutoDelete = DeleteAsyncOperationIfSuccessful;
 

--- a/Xrm.Sdk.PluginRegistration/Wrappers/CrmPluginStep.cs
+++ b/Xrm.Sdk.PluginRegistration/Wrappers/CrmPluginStep.cs
@@ -743,10 +743,14 @@ namespace Xrm.Sdk.PluginRegistration.Wrappers
             {
                 sdkStep.SdkMessageFilterId = new EntityReference(SdkMessageFilter.EntityLogicalName, MessageEntityId);
             }
-            // When MessageEntityId == Guid.Empty (Primary Entity = "none"):
-            // completely omit sdkmessagefilterid from the request rather than
-            // sending null, which triggers Dataverse dependency calculation errors
-            // in orgs with stale sdkmessagefilter records for deleted entities.
+            else if (StepId != Guid.Empty)
+            {
+                // Update case: explicit clear of sdkmessagefilterid when transitioning to "none"
+                // This ensures any existing SdkMessageFilter reference on the step is removed.
+                // For create cases (StepId == Guid.Empty) we continue to omit the field entirely
+                // to avoid triggering Dataverse dependency calculation errors for some orgs.
+                sdkStep.SdkMessageFilterId = null;
+            }
             sdkStep.ImpersonatingUserId = new EntityReference();
             sdkStep.ImpersonatingUserId.LogicalName = SystemUser.EntityLogicalName;
 


### PR DESCRIPTION
#### PR Classification
Bug fix and UX improvement for plugin step registration and attribute selection.

#### PR Summary
This PR enhances the Filtering Attributes dialog with bulk selection via paste, improves step registration robustness, and refines handling of filtering attributes to prevent Dataverse errors.
- AttributeSelectionForm.cs: Adds support for pasting comma-separated attribute names to bulk-select attributes.
- StepRegistrationForm.cs: Allows step registration with Primary Entity set to "none" and restricts "All Attributes" warning to non-Create messages.
- CrmPluginStep.cs: Omits sdkmessagefilterid when Primary Entity is "none" and refines filtering attributes field handling for create/update.
- OrganizationHelper.cs: Corrects minimum version for filtered attributes on "Create" and improves message entity handling.
- Xrm.Sdk.PluginRegistration.nuspec: Updates release notes to document new features and fixes.
