### PR TITLE
Fix: File/Image attributes missing from filtering attributes selector

### DIFF
--- a/Xrm.Sdk.PluginRegistration/Forms/AttributeSelectionForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/AttributeSelectionForm.cs
@@ -87,7 +87,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
                     ImageIndex = 0
                 };
                 item.SubItems.Add(attribute.LogicalName);
-                item.SubItems.Add(attribute.TypeName == "MultiSelectPicklistType" ? "MultiSelect Picklist" : attribute.Type.ToString());
+                item.SubItems.Add(GetDisplayTypeName(attribute));
                 item.Tag = attribute;
                 item.Checked = currentAllChecked || currentValue.Contains(item.Name);
                 var addattribute = false;
@@ -116,7 +116,14 @@ namespace Xrm.Sdk.PluginRegistration.Forms
                     case AttributeTypeCode.CalendarRules:
                     case AttributeTypeCode.Uniqueidentifier:
                     case AttributeTypeCode.Virtual:
-                        if (attribute.IsPrimaryId || attribute.TypeName == "MultiSelectPicklistType")
+                        // File and Image (new-style) attributes report AttributeType == Virtual, with the
+                        // concrete subtype distinguished via AttributeTypeName ("FileType" / "ImageType"),
+                        // the same way MultiSelectPicklistType is distinguished. Without these checks, File
+                        // and Image attributes were silently excluded from the filtering attributes list.
+                        if (attribute.IsPrimaryId
+                            || attribute.TypeName == "MultiSelectPicklistType"
+                            || attribute.TypeName == "FileType"
+                            || attribute.TypeName == "ImageType")
                         {
                             addattribute = true;
                         }
@@ -132,6 +139,21 @@ namespace Xrm.Sdk.PluginRegistration.Forms
         #endregion Public Constructors
 
         #region Private Methods
+
+        private static string GetDisplayTypeName(CrmAttribute attribute)
+        {
+            switch (attribute.TypeName)
+            {
+                case "MultiSelectPicklistType":
+                    return "MultiSelect Picklist";
+                case "FileType":
+                    return "File";
+                case "ImageType":
+                    return "Image";
+                default:
+                    return attribute.Type.ToString();
+            }
+        }
 
         private void AttributeSelectionForm_Load(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary

File and Image attributes never appear in the "Filtering Attributes" picker (opened from Step Registration), for Update or any other message that supports filtered attributes. They are silently excluded before the selection dialog even renders.

## Root cause

`AttributeSelectionForm`'s constructor builds its selectable attribute list from an explicit allow-list keyed on `AttributeTypeCode`:

```csharp
case AttributeTypeCode.CalendarRules:
case AttributeTypeCode.Uniqueidentifier:
case AttributeTypeCode.Virtual:
    if (attribute.IsPrimaryId || attribute.TypeName == "MultiSelectPicklistType")
    {
        addattribute = true;
    }
    break;
```

Dataverse doesn't give File or Image (new-style) columns their own `AttributeTypeCode`. Both report `AttributeType = Virtual` (the same code multi-select picklists use), and the concrete subtype is only distinguishable via `AttributeTypeName.Value` (`"FileType"` for File columns, `"ImageType"` for Image columns) - the exact mechanism already used here to special-case `"MultiSelectPicklistType"`.

Because the `Virtual` case only checked `IsPrimaryId` and `"MultiSelectPicklistType"`, every File and Image attribute fell through with `addattribute == false` and was dropped from `m_attributesList` before the form loaded.

`CrmAttribute` (`Wrappers/CrmAttribute.cs`) is unaffected - it passes through whatever `AttributeType`/`AttributeTypeName` the metadata service returns. The bug is isolated to the allow-list in `AttributeSelectionForm`.

## Fix

- Add `"FileType"` and `"ImageType"` to the existing `TypeName` check in the `Virtual` case, alongside `"MultiSelectPicklistType"`, so File and Image attributes are included in the selectable list.
- - Extract the inline type-name-to-display-string ternary into a `GetDisplayTypeName` helper and extend it to show `"File"` / `"Image"` in the Type column, instead of the generic `"Virtual"` `AttributeTypeCode` - consistent with how `"MultiSelect Picklist"` is already shown instead of `"Virtual"`.
No other files needed changes; the `CrmAttribute[]` flowing into this form already carries the correct `AttributeTypeName`.

## Testing

This is a .NET Framework 4.8 WinForms project, so it wasn't feasible to build/run it in the environment used to prepare this change. The change was reviewed by hand: it only extends an existing allow-list with two additional `AttributeTypeName` values and extracts a passthrough display-name helper, with no changes to behavior for any previously-supported attribute type.

Manual verification recommended before merge: register/edit a step for the Update message on an entity with a File or Image attribute (e.g. a custom File column) and confirm it now appears, checkable, in the Filtering Attributes dialog, with "File"/"Image" shown in the Type column.

## Risk

Low. Only widens the existing allow-list for two additional `AttributeTypeName` values and adds a passthrough helper for display text; no behavior changes for attribute types that were already supported.