### PR TITLE
#169 Widen the left column and grow Filtering Attributes to fit its value

### DIFF
--- a/Xrm.Sdk.PluginRegistration/Controls/CrmAttributeSelectionControl.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Controls/CrmAttributeSelectionControl.Designer.cs
@@ -35,8 +35,7 @@ namespace Xrm.Sdk.PluginRegistration.Controls
             // 
             // btnSelect
             // 
-            this.btnSelect.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSelect.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnSelect.Location = new System.Drawing.Point(326, 0);
             this.btnSelect.Name = "btnSelect";
             this.btnSelect.Size = new System.Drawing.Size(36, 20);

--- a/Xrm.Sdk.PluginRegistration/Controls/CrmAttributeSelectionControl.cs
+++ b/Xrm.Sdk.PluginRegistration/Controls/CrmAttributeSelectionControl.cs
@@ -142,6 +142,26 @@ namespace Xrm.Sdk.PluginRegistration.Controls
             }
         }
 
+        /// <summary>
+        /// Height this control would need to show its entire value at the current width.
+        /// May be smaller than the current height when the value is short.
+        /// </summary>
+        [Browsable(false)]
+        public int ContentHeight
+        {
+            get
+            {
+                var proposedSize = new System.Drawing.Size(txtAttributes.ClientSize.Width, int.MaxValue);
+                var flags = TextFormatFlags.WordBreak | TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding;
+
+                int textHeight = TextRenderer.MeasureText(
+                    txtAttributes.Text ?? string.Empty, txtAttributes.Font, proposedSize, flags).Height;
+
+                //Add back whatever the border and any other chrome takes up
+                return textHeight + (Height - txtAttributes.ClientSize.Height);
+            }
+        }
+
         [Browsable(false)]
         public bool HasAttributes
         {

--- a/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
@@ -1,4 +1,4 @@
-namespace Xrm.Sdk.PluginRegistration.Forms
+﻿namespace Xrm.Sdk.PluginRegistration.Forms
 {
     partial class StepRegistrationForm
     {        
@@ -78,6 +78,8 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpDescription = new System.Windows.Forms.GroupBox();
             this.txtDescription = new System.Windows.Forms.RichTextBox();
             this.tlpRightColumn = new System.Windows.Forms.TableLayoutPanel();
+            this.tlpMain = new System.Windows.Forms.TableLayoutPanel();
+            this.pnlLeftColumn = new System.Windows.Forms.Panel();
             this.grpGeneral.SuspendLayout();
             this.grpSecureConfiguration.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picInvalidSecureConfigurationId)).BeginInit();
@@ -89,6 +91,8 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpStage.SuspendLayout();
             this.grpDescription.SuspendLayout();
             this.tlpRightColumn.SuspendLayout();
+            this.tlpMain.SuspendLayout();
+            this.pnlLeftColumn.SuspendLayout();
             this.SuspendLayout();
             // 
             // grpGeneral
@@ -110,7 +114,9 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpGeneral.Controls.Add(this.lblMessageName);
             this.grpGeneral.Controls.Add(this.cmbWebhook);
             this.grpGeneral.Controls.Add(this.cmbPlugins);
-            this.grpGeneral.Location = new System.Drawing.Point(12, 12);
+            this.grpGeneral.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpGeneral.Location = new System.Drawing.Point(0, 2);
             this.grpGeneral.Name = "grpGeneral";
             this.grpGeneral.Size = new System.Drawing.Size(451, 229);
             this.grpGeneral.TabIndex = 0;
@@ -404,7 +410,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.grpMode.Controls.Add(this.radModeSync);
             this.grpMode.Controls.Add(this.radModeAsync);
-            this.grpMode.Location = new System.Drawing.Point(218, 247);
+            this.grpMode.Location = new System.Drawing.Point(206, 237);
             this.grpMode.Name = "grpMode";
             this.grpMode.Size = new System.Drawing.Size(102, 65);
             this.grpMode.TabIndex = 3;
@@ -442,7 +448,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.grpDeployment.Controls.Add(this.chkDeploymentOffline);
             this.grpDeployment.Controls.Add(this.chkDeploymentServer);
-            this.grpDeployment.Location = new System.Drawing.Point(326, 247);
+            this.grpDeployment.Location = new System.Drawing.Point(314, 237);
             this.grpDeployment.Name = "grpDeployment";
             this.grpDeployment.Size = new System.Drawing.Size(88, 65);
             this.grpDeployment.TabIndex = 4;
@@ -479,7 +485,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.grpInvocation.Controls.Add(this.radInvocationChild);
             this.grpInvocation.Controls.Add(this.radInvocationParent);
-            this.grpInvocation.Location = new System.Drawing.Point(218, 316);
+            this.grpInvocation.Location = new System.Drawing.Point(206, 306);
             this.grpInvocation.Name = "grpInvocation";
             this.grpInvocation.Size = new System.Drawing.Size(196, 65);
             this.grpInvocation.TabIndex = 5;
@@ -557,7 +563,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.radStagePostOperationDeprecated.AutoSize = true;
             this.radStagePostOperationDeprecated.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radStagePostOperationDeprecated.Location = new System.Drawing.Point(18, 358);
+            this.radStagePostOperationDeprecated.Location = new System.Drawing.Point(6, 348);
             this.radStagePostOperationDeprecated.Name = "radStagePostOperationDeprecated";
             this.radStagePostOperationDeprecated.Size = new System.Drawing.Size(156, 17);
             this.radStagePostOperationDeprecated.TabIndex = 3;
@@ -625,7 +631,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpStage.Controls.Add(this.radStagePostOperation);
             this.grpStage.Controls.Add(this.radStagePreOperation);
             this.grpStage.Controls.Add(this.radStagePreValidation);
-            this.grpStage.Location = new System.Drawing.Point(12, 247);
+            this.grpStage.Location = new System.Drawing.Point(0, 237);
             this.grpStage.Name = "grpStage";
             this.grpStage.Size = new System.Drawing.Size(200, 92);
             this.grpStage.TabIndex = 2;
@@ -635,7 +641,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // chkDeleteAsyncOperationIfSuccessful
             // 
             this.chkDeleteAsyncOperationIfSuccessful.Enabled = false;
-            this.chkDeleteAsyncOperationIfSuccessful.Location = new System.Drawing.Point(12, 392);
+            this.chkDeleteAsyncOperationIfSuccessful.Location = new System.Drawing.Point(0, 382);
             this.chkDeleteAsyncOperationIfSuccessful.Name = "chkDeleteAsyncOperationIfSuccessful";
             this.chkDeleteAsyncOperationIfSuccessful.Size = new System.Drawing.Size(402, 16);
             this.chkDeleteAsyncOperationIfSuccessful.TabIndex = 5;
@@ -670,15 +676,14 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             //
             // tlpRightColumn
             //
-            this.tlpRightColumn.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.tlpRightColumn.ColumnCount = 1;
             this.tlpRightColumn.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpRightColumn.Controls.Add(this.grpDescription, 0, 0);
             this.tlpRightColumn.Controls.Add(this.grpUnsecureConfig, 0, 1);
             this.tlpRightColumn.Controls.Add(this.grpSecureConfiguration, 0, 2);
-            this.tlpRightColumn.Location = new System.Drawing.Point(466, 10);
+            this.tlpRightColumn.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tlpRightColumn.Location = new System.Drawing.Point(457, 0);
+            this.tlpRightColumn.Margin = new System.Windows.Forms.Padding(0);
             this.tlpRightColumn.Name = "tlpRightColumn";
             this.tlpRightColumn.RowCount = 3;
             this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 89F));
@@ -687,6 +692,39 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.tlpRightColumn.Size = new System.Drawing.Size(439, 398);
             this.tlpRightColumn.TabIndex = 6;
             //
+            // pnlLeftColumn
+            //
+            this.pnlLeftColumn.Controls.Add(this.grpGeneral);
+            this.pnlLeftColumn.Controls.Add(this.grpStage);
+            this.pnlLeftColumn.Controls.Add(this.grpMode);
+            this.pnlLeftColumn.Controls.Add(this.grpDeployment);
+            this.pnlLeftColumn.Controls.Add(this.grpInvocation);
+            this.pnlLeftColumn.Controls.Add(this.radStagePostOperationDeprecated);
+            this.pnlLeftColumn.Controls.Add(this.chkDeleteAsyncOperationIfSuccessful);
+            this.pnlLeftColumn.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlLeftColumn.Location = new System.Drawing.Point(3, 0);
+            this.pnlLeftColumn.Margin = new System.Windows.Forms.Padding(3, 0, 3, 0);
+            this.pnlLeftColumn.Name = "pnlLeftColumn";
+            this.pnlLeftColumn.Size = new System.Drawing.Size(451, 398);
+            this.pnlLeftColumn.TabIndex = 0;
+            //
+            // tlpMain
+            //
+            this.tlpMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tlpMain.ColumnCount = 2;
+            this.tlpMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 51.1F));
+            this.tlpMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 48.9F));
+            this.tlpMain.Controls.Add(this.pnlLeftColumn, 0, 0);
+            this.tlpMain.Controls.Add(this.tlpRightColumn, 1, 0);
+            this.tlpMain.Location = new System.Drawing.Point(9, 10);
+            this.tlpMain.Name = "tlpMain";
+            this.tlpMain.RowCount = 1;
+            this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpMain.Size = new System.Drawing.Size(896, 398);
+            this.tlpMain.TabIndex = 0;
+            //
             // StepRegistrationForm
             //
             this.AcceptButton = this.btnRegister;
@@ -694,16 +732,9 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(907, 445);
-            this.Controls.Add(this.tlpRightColumn);
-            this.Controls.Add(this.chkDeleteAsyncOperationIfSuccessful);
-            this.Controls.Add(this.radStagePostOperationDeprecated);
+            this.Controls.Add(this.tlpMain);
             this.Controls.Add(this.btnCancel);
-            this.Controls.Add(this.grpDeployment);
             this.Controls.Add(this.btnRegister);
-            this.Controls.Add(this.grpInvocation);
-            this.Controls.Add(this.grpStage);
-            this.Controls.Add(this.grpMode);
-            this.Controls.Add(this.grpGeneral);
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(921, 478);
             this.Name = "StepRegistrationForm";
@@ -729,6 +760,8 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpStage.PerformLayout();
             this.grpDescription.ResumeLayout(false);
             this.tlpRightColumn.ResumeLayout(false);
+            this.pnlLeftColumn.ResumeLayout(false);
+            this.tlpMain.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -785,5 +818,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
         private System.Windows.Forms.ComboBox cmbServiceEndpoint;
         private System.Windows.Forms.ComboBox cmbWebhook;
         private System.Windows.Forms.TableLayoutPanel tlpRightColumn;
+        private System.Windows.Forms.TableLayoutPanel tlpMain;
+        private System.Windows.Forms.Panel pnlLeftColumn;
     }
 }

--- a/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
@@ -317,7 +317,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpSecureConfiguration.Controls.Add(this.picAccessDenied);
             this.grpSecureConfiguration.Controls.Add(this.txtSecureConfig);
             this.grpSecureConfiguration.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpSecureConfiguration.Location = new System.Drawing.Point(3, 288);
+            this.grpSecureConfiguration.Location = new System.Drawing.Point(3, 225);
             this.grpSecureConfiguration.Name = "grpSecureConfiguration";
             this.grpSecureConfiguration.Size = new System.Drawing.Size(427, 168);
             this.grpSecureConfiguration.TabIndex = 9;
@@ -570,7 +570,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             this.grpUnsecureConfig.Controls.Add(this.txtUnsecureConfiguration);
             this.grpUnsecureConfig.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpUnsecureConfig.Location = new System.Drawing.Point(3, 155);
+            this.grpUnsecureConfig.Location = new System.Drawing.Point(3, 92);
             this.grpUnsecureConfig.Name = "grpUnsecureConfig";
             this.grpUnsecureConfig.Size = new System.Drawing.Size(427, 127);
             this.grpUnsecureConfig.TabIndex = 8;
@@ -648,7 +648,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpDescription.Dock = System.Windows.Forms.DockStyle.Fill;
             this.grpDescription.Location = new System.Drawing.Point(3, 3);
             this.grpDescription.Name = "grpDescription";
-            this.grpDescription.Size = new System.Drawing.Size(427, 146);
+            this.grpDescription.Size = new System.Drawing.Size(427, 83);
             this.grpDescription.TabIndex = 6;
             this.grpDescription.TabStop = false;
             this.grpDescription.Text = "Description";
@@ -681,9 +681,9 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.tlpRightColumn.Location = new System.Drawing.Point(466, 10);
             this.tlpRightColumn.Name = "tlpRightColumn";
             this.tlpRightColumn.RowCount = 3;
-            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 22F));
-            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 34F));
-            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 44F));
+            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 89F));
+            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 43F));
+            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 57F));
             this.tlpRightColumn.Size = new System.Drawing.Size(439, 398);
             this.tlpRightColumn.TabIndex = 6;
             //

--- a/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.Designer.cs
@@ -77,6 +77,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.chkDeleteAsyncOperationIfSuccessful = new System.Windows.Forms.CheckBox();
             this.grpDescription = new System.Windows.Forms.GroupBox();
             this.txtDescription = new System.Windows.Forms.RichTextBox();
+            this.tlpRightColumn = new System.Windows.Forms.TableLayoutPanel();
             this.grpGeneral.SuspendLayout();
             this.grpSecureConfiguration.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picInvalidSecureConfigurationId)).BeginInit();
@@ -87,6 +88,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpUnsecureConfig.SuspendLayout();
             this.grpStage.SuspendLayout();
             this.grpDescription.SuspendLayout();
+            this.tlpRightColumn.SuspendLayout();
             this.SuspendLayout();
             // 
             // grpGeneral
@@ -308,17 +310,16 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             // grpSecureConfiguration
             // 
-            this.grpSecureConfiguration.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.grpSecureConfiguration.Controls.Add(this.lnkInvalidSecureConfigurationId);
             this.grpSecureConfiguration.Controls.Add(this.lblInvalidSecureConfigurationId);
             this.grpSecureConfiguration.Controls.Add(this.picInvalidSecureConfigurationId);
             this.grpSecureConfiguration.Controls.Add(this.lblAccessDenied);
             this.grpSecureConfiguration.Controls.Add(this.picAccessDenied);
             this.grpSecureConfiguration.Controls.Add(this.txtSecureConfig);
-            this.grpSecureConfiguration.Location = new System.Drawing.Point(469, 238);
+            this.grpSecureConfiguration.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpSecureConfiguration.Location = new System.Drawing.Point(3, 288);
             this.grpSecureConfiguration.Name = "grpSecureConfiguration";
-            this.grpSecureConfiguration.Size = new System.Drawing.Size(433, 170);
+            this.grpSecureConfiguration.Size = new System.Drawing.Size(427, 168);
             this.grpSecureConfiguration.TabIndex = 9;
             this.grpSecureConfiguration.TabStop = false;
             this.grpSecureConfiguration.Text = "Secure Configuration";
@@ -567,11 +568,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             // grpUnsecureConfig
             // 
-            this.grpUnsecureConfig.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.grpUnsecureConfig.Controls.Add(this.txtUnsecureConfiguration);
-            this.grpUnsecureConfig.Location = new System.Drawing.Point(469, 103);
+            this.grpUnsecureConfig.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpUnsecureConfig.Location = new System.Drawing.Point(3, 155);
             this.grpUnsecureConfig.Name = "grpUnsecureConfig";
-            this.grpUnsecureConfig.Size = new System.Drawing.Size(433, 129);
+            this.grpUnsecureConfig.Size = new System.Drawing.Size(427, 127);
             this.grpUnsecureConfig.TabIndex = 8;
             this.grpUnsecureConfig.TabStop = false;
             this.grpUnsecureConfig.Text = "Unsecure Configuration";
@@ -643,12 +644,11 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             // 
             // grpDescription
             // 
-            this.grpDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.grpDescription.Controls.Add(this.txtDescription);
-            this.grpDescription.Location = new System.Drawing.Point(469, 13);
+            this.grpDescription.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpDescription.Location = new System.Drawing.Point(3, 3);
             this.grpDescription.Name = "grpDescription";
-            this.grpDescription.Size = new System.Drawing.Size(433, 83);
+            this.grpDescription.Size = new System.Drawing.Size(427, 146);
             this.grpDescription.TabIndex = 6;
             this.grpDescription.TabStop = false;
             this.grpDescription.Text = "Description";
@@ -667,25 +667,42 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.txtDescription.Text = "";
             this.txtDescription.Enter += new System.EventHandler(this.longText_Enter);
             this.txtDescription.Leave += new System.EventHandler(this.longText_Leave);
-            // 
+            //
+            // tlpRightColumn
+            //
+            this.tlpRightColumn.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tlpRightColumn.ColumnCount = 1;
+            this.tlpRightColumn.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpRightColumn.Controls.Add(this.grpDescription, 0, 0);
+            this.tlpRightColumn.Controls.Add(this.grpUnsecureConfig, 0, 1);
+            this.tlpRightColumn.Controls.Add(this.grpSecureConfiguration, 0, 2);
+            this.tlpRightColumn.Location = new System.Drawing.Point(466, 10);
+            this.tlpRightColumn.Name = "tlpRightColumn";
+            this.tlpRightColumn.RowCount = 3;
+            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 22F));
+            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 34F));
+            this.tlpRightColumn.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 44F));
+            this.tlpRightColumn.Size = new System.Drawing.Size(439, 398);
+            this.tlpRightColumn.TabIndex = 6;
+            //
             // StepRegistrationForm
-            // 
+            //
             this.AcceptButton = this.btnRegister;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(907, 445);
-            this.Controls.Add(this.grpDescription);
+            this.Controls.Add(this.tlpRightColumn);
             this.Controls.Add(this.chkDeleteAsyncOperationIfSuccessful);
             this.Controls.Add(this.radStagePostOperationDeprecated);
-            this.Controls.Add(this.grpUnsecureConfig);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.grpDeployment);
             this.Controls.Add(this.btnRegister);
             this.Controls.Add(this.grpInvocation);
             this.Controls.Add(this.grpStage);
             this.Controls.Add(this.grpMode);
-            this.Controls.Add(this.grpSecureConfiguration);
             this.Controls.Add(this.grpGeneral);
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(921, 478);
@@ -711,6 +728,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.grpStage.ResumeLayout(false);
             this.grpStage.PerformLayout();
             this.grpDescription.ResumeLayout(false);
+            this.tlpRightColumn.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -766,5 +784,6 @@ namespace Xrm.Sdk.PluginRegistration.Forms
         private System.Windows.Forms.PictureBox picInvalidSecureConfigurationId;
         private System.Windows.Forms.ComboBox cmbServiceEndpoint;
         private System.Windows.Forms.ComboBox cmbWebhook;
+        private System.Windows.Forms.TableLayoutPanel tlpRightColumn;
     }
 }

--- a/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.cs
+++ b/Xrm.Sdk.PluginRegistration/Forms/StepRegistrationForm.cs
@@ -41,6 +41,16 @@ namespace Xrm.Sdk.PluginRegistration.Forms
 
         private string m_stepName = string.Empty;
 
+        //Baseline geometry captured once, used to grow crmFilteringAttributes into the
+        //spare vertical space of the left column when its value does not fit on one line
+        private readonly Dictionary<Control, int> m_baseTopBelowFilteringAttributes = new Dictionary<Control, int>();
+        private readonly Dictionary<Control, int> m_baseTopBelowGeneral = new Dictionary<Control, int>();
+        private int m_appliedFilteringAttributesGrowth = 0;
+        private int m_baseFilteringAttributesHeight;
+        private int m_baseGeneralHeight;
+        private int m_baseLeftColumnHeight;
+        private bool m_filteringAttributesLayoutCaptured = false;
+
         #endregion Private Fields
 
         #region Public Constructors
@@ -81,12 +91,16 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             this.crmFilteringAttributes.ScrollBars = ScrollBars.None;
             this.crmFilteringAttributes.Size = new System.Drawing.Size(316, 20);
             this.crmFilteringAttributes.TabIndex = 9;
-            this.crmFilteringAttributes.WordWrap = false;
+            this.crmFilteringAttributes.WordWrap = true;
 
             #endregion Initialization of crmFilteringAttributes
 
             InitializeComponent();
             this.grpGeneral.Controls.Add(this.crmFilteringAttributes);
+
+            CaptureFilteringAttributesLayout();
+            this.crmFilteringAttributes.AttributesChanged += new EventHandler<EventArgs>(this.crmFilteringAttributes_AttributesChanged);
+            this.pnlLeftColumn.SizeChanged += new EventHandler(this.pnlLeftColumn_SizeChanged);
 
             //Initialize the auto-complete on the Message field
             var msgList = new AutoCompleteStringCollection();
@@ -354,6 +368,7 @@ namespace Xrm.Sdk.PluginRegistration.Forms
                 }
 
                 crmFilteringAttributes.Attributes = m_currentStep.FilteringAttributes;
+                ApplyFilteringAttributesLayout();
                 chkDeleteAsyncOperationIfSuccessful.Checked = m_currentStep.DeleteAsyncOperationIfSuccessful;
                 chkDeleteAsyncOperationIfSuccessful.Enabled = (m_currentStep.Mode == CrmPluginStepMode.Asynchronous);
 
@@ -863,6 +878,8 @@ namespace Xrm.Sdk.PluginRegistration.Forms
                 crmFilteringAttributes.Enabled = false;
                 crmFilteringAttributes.DisabledMessage = "Message/Entity does not support Filtered Attributes";
             }
+
+            ApplyFilteringAttributesLayout();
         }
 
         private void CheckDeploymentSupported()
@@ -1148,6 +1165,99 @@ namespace Xrm.Sdk.PluginRegistration.Forms
             {
                 m_stepName = GenerateDescription();
             }
+        }
+
+        /// <summary>
+        /// Records where everything sits before any growth is applied, so that
+        /// ApplyFilteringAttributesLayout can always work from the original positions
+        /// rather than accumulating offsets.
+        /// </summary>
+        private void CaptureFilteringAttributesLayout()
+        {
+            m_baseFilteringAttributesHeight = crmFilteringAttributes.Height;
+            m_baseGeneralHeight = grpGeneral.Height;
+
+            foreach (Control control in grpGeneral.Controls)
+            {
+                //Strictly below the row, so that lblFilteringAttributes stays put
+                if (control.Top >= crmFilteringAttributes.Bottom)
+                {
+                    m_baseTopBelowFilteringAttributes.Add(control, control.Top);
+                }
+            }
+
+            m_baseLeftColumnHeight = 0;
+            foreach (Control control in pnlLeftColumn.Controls)
+            {
+                if (control != grpGeneral)
+                {
+                    m_baseTopBelowGeneral.Add(control, control.Top);
+                }
+
+                if (control.Bottom > m_baseLeftColumnHeight)
+                {
+                    m_baseLeftColumnHeight = control.Bottom;
+                }
+            }
+
+            m_filteringAttributesLayoutCaptured = true;
+        }
+
+        /// <summary>
+        /// Grows the Filtering Attributes field so a long attribute list becomes readable,
+        /// but only as far as the value needs and as far as the spare height in the left
+        /// column allows. Everything below it moves down by the same amount.
+        /// </summary>
+        private void ApplyFilteringAttributesLayout()
+        {
+            if (!m_filteringAttributesLayoutCaptured)
+            {
+                return;
+            }
+
+            int spare = pnlLeftColumn.ClientSize.Height - m_baseLeftColumnHeight;
+            int wanted = crmFilteringAttributes.ContentHeight - m_baseFilteringAttributesHeight;
+            int growth = crmFilteringAttributes.Enabled ? Math.Max(0, Math.Min(wanted, spare)) : 0;
+
+            if (growth != m_appliedFilteringAttributesGrowth)
+            {
+                pnlLeftColumn.SuspendLayout();
+                grpGeneral.SuspendLayout();
+
+                crmFilteringAttributes.Height = m_baseFilteringAttributesHeight + growth;
+                foreach (KeyValuePair<Control, int> control in m_baseTopBelowFilteringAttributes)
+                {
+                    control.Key.Top = control.Value + growth;
+                }
+
+                grpGeneral.Height = m_baseGeneralHeight + growth;
+                foreach (KeyValuePair<Control, int> control in m_baseTopBelowGeneral)
+                {
+                    control.Key.Top = control.Value + growth;
+                }
+
+                grpGeneral.ResumeLayout();
+                pnlLeftColumn.ResumeLayout();
+
+                m_appliedFilteringAttributesGrowth = growth;
+            }
+
+            //Only offer a scrollbar when the value still does not fit after growing
+            ScrollBars scrollBars = wanted > growth ? ScrollBars.Vertical : ScrollBars.None;
+            if (crmFilteringAttributes.ScrollBars != scrollBars)
+            {
+                crmFilteringAttributes.ScrollBars = scrollBars;
+            }
+        }
+
+        private void crmFilteringAttributes_AttributesChanged(object sender, EventArgs e)
+        {
+            ApplyFilteringAttributesLayout();
+        }
+
+        private void pnlLeftColumn_SizeChanged(object sender, EventArgs e)
+        {
+            ApplyFilteringAttributesLayout();
         }
 
         private void txtRank_KeyPress(object sender, KeyPressEventArgs e)


### PR DESCRIPTION
Follow-up to #169, covering the left-hand column of the same dialog. Builds on #170.

> [!IMPORTANT]
> **Stacked on top of the right-column PR — please merge that one first.**
> The commit here moves `tlpRightColumn` (introduced by that PR) into a new `tlpMain`, so it cannot stand alone on `master`. Because the base branch lives in a fork, this PR has to target `master` directly and therefore shows the right-column commits as well. Once the right-column PR is merged, the diff here reduces to the single left-column commit.
>
> The left-column change on its own: [`fix/step-form-right-column-layout...fix/step-form-left-column-layout`](https://github.com/comentality/PluginRegistration/compare/fix/step-form-right-column-layout...fix/step-form-left-column-layout)

## Problem

Two separate things, both visible when the window is stretched:

1. **`grpGeneral` had no `Anchor` at all**, so it defaulted to `Top, Left` and stayed frozen at 451x229 no matter how far the window was dragged — horizontally or vertically. Every field inside it already had `Left, Right` anchors and was ready to widen; it just never got the chance. At 1400px wide there is roughly 500px of unused width sitting next to a clipped `Name` field.

2. **Filtering Attributes clipped its value with no way to read it.** `txtAttributes` is `Multiline` but was configured `WordWrap = false`, `ReadOnly = true`, and `ScrollBars = None` (set in `StepRegistrationForm.cs`). A 20-attribute list rendered as `accountnumber, accountratingcode, address1_city, addr...` and could not be scrolled, wrapped, or selected past the edge. The only way to see the whole value was to open the `...` dialog.

## Fix

**Both columns now widen.** A new `tlpMain` splits the form 51.1% / 48.9%. The left column's controls are hosted in a new `pnlLeftColumn`, and `grpGeneral` is anchored `Top, Left, Right`. Anchoring `grpGeneral` to the right on its own would not work — its right edge would follow the frame while the right column's left edge stayed put, and the two would overlap — so the width has to actually be split.

**Filtering Attributes grows to fit its value.** It now word-wraps and expands into the spare vertical space of the left column, bounded by what the value actually needs. The rows below it and the group boxes under `grpGeneral` shift down by the same amount. When there is no spare room it falls back to a vertical scrollbar.

A new `ContentHeight` property on `CrmAttributeSelectionControl` measures the height the value needs at the current width. The `...` button lost its `Bottom` anchor so it no longer stretches to the full height of the grown field.

## Before / after

Both captured at a client size of 1400x900, with a 20-attribute filtering list.

| Before (right-column branch) | After |
|---|---|
| <img src="https://raw.githubusercontent.com/comentality/PluginRegistration/step-form-layout-screenshots/screenshots/left-before-wide.png" width="420"> | <img src="https://raw.githubusercontent.com/comentality/PluginRegistration/step-form-layout-screenshots/screenshots/left-after-wide.png" width="420"> |

Tall and narrow, 907x1100 — the field wraps to more lines because the column is narrower:

<img src="https://raw.githubusercontent.com/comentality/PluginRegistration/step-form-layout-screenshots/screenshots/left-after-extended.png" width="420">

## Measured behaviour

| Client size | `grpGeneral` | Filter field | Height needed | Scrollbar |
|---|---|---|---|---|
| 907x445 (default) | 451x229 @ x12 | 316x20 | 95 | Vertical |
| 907x700 | 451x304 | 316x95 | 95 | None |
| 907x1100 | 451x304 | 316x95 | 95 | None |
| 1400x900 | 703x265 | 568x56 | 56 | None |
| 1400x1100 | 703x265 | 568x56 | 56 | None |

Two things worth reading off that table:

- At the default size the geometry is identical to before this PR — `grpGeneral` is 451x229 at x=12 and the right column is 439 wide at x=466.
- Growth stops at what the value needs, not at the window edge: 1100px tall gives the same result as 700px, and a *wider* window needs *fewer* lines so the field grows *less*.

## Testing

- Manual testing on the running tool: resizing the window, and across different DPI settings and display scaling factors.
- The screenshots and the table above were produced from the real `StepRegistrationForm.Designer.cs` and `CrmAttributeSelectionControl.Designer.cs` of each branch, resized at runtime.
- Solution builds clean.

## Notes

- The disabled state (`DisabledMessage` shown when the message/entity does not support filtered attributes) forces growth to `0`, so the field stays at its original height. That path was not rendered during testing.
- `UpdatePluginEventHandlerControls` copies `cmbPlugins.Location`/`.Size` onto `cmbWebhook` and `cmbServiceEndpoint`. All three move together with the rest of the rows, so the three stacked combos stay in sync.
